### PR TITLE
Get verbose output from Mixpanel and return more info

### DIFF
--- a/src/Mixpanel.NET.PCL/EventTracker.cs
+++ b/src/Mixpanel.NET.PCL/EventTracker.cs
@@ -76,7 +76,7 @@ namespace Mixpanel.NET.PCL
 
             var request = RequestHelpers.GetRequestMessageFromDictionaryAndEndpoint (Constants.TrackUri, dataDictionary);
 
-            return RequestHelpers.GetRequestOutput (request);
+            return RequestHelpers.MakeRequest (request);
         }
 
         /// <summary>

--- a/src/Mixpanel.NET.PCL/EventTracker.cs
+++ b/src/Mixpanel.NET.PCL/EventTracker.cs
@@ -10,10 +10,10 @@ namespace Mixpanel.NET.PCL
         /// <summary>
         /// Track a new event
         /// </summary>
-        /// <returns>True if event was tracked, false otherwise</returns>
+        /// <returns>The response from mixpanel</returns>
         /// <param name="profile">Profile.</param>
         /// <param name="mixpanelEvent">Mixpanel event.</param>
-        public static Task<bool> Track (Profile profile, IMixpanelEvent mixpanelEvent)
+        public static Task<MixpanelResponse> Track (Profile profile, IMixpanelEvent mixpanelEvent)
         {
             if (mixpanelEvent == null)
             {
@@ -29,9 +29,9 @@ namespace Mixpanel.NET.PCL
         /// <summary>
         /// Track a new event
         /// </summary>
-        /// <returns>True if event was tracked, false otherwise</returns>
+        /// <returns>The response from mixpanel</returns>
         /// <param name="mixpanelEvent">Mixpanel event.</param>
-        public static Task<bool> Track (IMixpanelEvent mixpanelEvent)
+        public static Task<MixpanelResponse> Track (IMixpanelEvent mixpanelEvent)
         {
             return Track (null, mixpanelEvent);
         }
@@ -39,11 +39,11 @@ namespace Mixpanel.NET.PCL
         /// <summary>
         /// Track a new event
         /// </summary>
-        /// <returns>True if event was tracked, false otherwise</returns>
+        /// <returns>The response from mixpanel</returns>
         /// <param name="profile">Profile.</param>
         /// <param name="eventName">Event name.</param>
         /// <param name="properties">Properties</param>
-        public static Task<bool> Track (Profile profile, string eventName,
+        public static Task<MixpanelResponse> Track (Profile profile, string eventName,
                                         Dictionary<string, object> properties)
         {
             if (Client.Token == null)
@@ -76,16 +76,16 @@ namespace Mixpanel.NET.PCL
 
             var request = RequestHelpers.GetRequestMessageFromDictionaryAndEndpoint (Constants.TrackUri, dataDictionary);
 
-            return RequestHelpers.MakeRequest (request);
+            return RequestHelpers.GetRequestOutput (request);
         }
 
         /// <summary>
         /// Track a new event
         /// </summary>
-        /// <returns>True if event was tracked, false otherwise</returns>
+        /// <returns>The response from mixpanel</returns>
         /// <param name="eventName">Event name.</param>
         /// <param name="properties">Properties</param>
-        public static Task<bool> Track (string eventName,
+        public static Task<MixpanelResponse> Track (string eventName,
                                        Dictionary<string, object> properties)
         {
             return Track (null, eventName, properties);
@@ -94,9 +94,9 @@ namespace Mixpanel.NET.PCL
         /// <summary>
         /// Track a new event
         /// </summary>
-        /// <returns>True if event was tracked, false otherwise</returns>
+        /// <returns>The response from mixpanel</returns>
         /// <param name="eventName">Event name.</param>
-        public static Task<bool> Track (string eventName)
+        public static Task<MixpanelResponse> Track (string eventName)
         {
             return Track (null, eventName, null);
         }

--- a/src/Mixpanel.NET.PCL/Mixpanel.NET.PCL.csproj
+++ b/src/Mixpanel.NET.PCL/Mixpanel.NET.PCL.csproj
@@ -39,6 +39,7 @@
     <Compile Include="Profile.cs" />
     <Compile Include="Client.cs" />
     <Compile Include="RequestHelpers.cs" />
+    <Compile Include="MixpanelResponse.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json">

--- a/src/Mixpanel.NET.PCL/MixpanelResponse.cs
+++ b/src/Mixpanel.NET.PCL/MixpanelResponse.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Mixpanel.NET.PCL
+{
+    public class MixpanelResponse
+    {
+        public bool Status { get; }
+        public string Error { get; }
+
+        [JsonConstructor]
+        public MixpanelResponse (bool status, string message = null)
+        {
+            Status = status;
+            Error = message;
+        }
+    }
+}

--- a/src/Mixpanel.NET.PCL/Profile.cs
+++ b/src/Mixpanel.NET.PCL/Profile.cs
@@ -41,8 +41,9 @@ namespace Mixpanel.NET.PCL
         /// It is possible to decrement by calling Add with negative values.
         /// This is useful for maintaining the values of properties like "Number of Logins" or "Files Uploaded".
         /// </summary>
+        /// <returns>The response from mixpanel</returns>
         /// <param name="properties">Properties.</param>
-        public Task<bool> Add(Dictionary<string, int> properties)
+        public Task<MixpanelResponse> Add(Dictionary<string, int> properties)
         {
             return Engage ("$add", properties);
         }
@@ -51,8 +52,9 @@ namespace Mixpanel.NET.PCL
         /// Takes a dictionary containing keys and values, and appends each to a list associated with the corresponding property name. 
         /// Appending to a property that doesn't exist will result in assigning a list with one element to that property.
         /// </summary>
+        /// <returns>The response from mixpanel</returns>
         /// <param name="properties">Properties.</param>
-        public Task<bool> Append (Dictionary<string, string> properties)
+        public Task<MixpanelResponse> Append (Dictionary<string, string> properties)
         {
             return Engage ("$append", properties);
         }
@@ -60,8 +62,8 @@ namespace Mixpanel.NET.PCL
         /// <summary>
         /// Permanently delete the profile from Mixpanel, along with all of its properties. 
         /// </summary>
-        /// <returns>True if the profile was deleted, false otherwise</returns>
-        public Task<bool> Delete ()
+        /// <returns>The response from mixpanel</returns>
+        public Task<MixpanelResponse> Delete ()
         {
             return Engage ("$delete", string.Empty);
         }
@@ -71,8 +73,9 @@ namespace Mixpanel.NET.PCL
         /// The value in the request is removed from the existing list on the user profile. 
         /// If it does not exist, no updates are made.
         /// </summary>
+        /// <returns>The response from mixpanel</returns>
         /// <param name="properties">Properties.</param>
-        public Task<bool> Remove (Dictionary<string, string> properties)
+        public Task<MixpanelResponse> Remove (Dictionary<string, string> properties)
         {
             return Engage ("$remove", properties);
         }
@@ -83,9 +86,9 @@ namespace Mixpanel.NET.PCL
         /// If the profile does not exist, it creates it with these properties. 
         /// If it does exist, it sets the properties to these values, overwriting existing values.
         /// </summary>
-        /// /// <returns>True if the set worked, false otherwise</returns>
+        /// <returns>The response from mixpanel</returns>
         /// <param name="properties">Properties of the profile</param>
-        public Task<bool> Set (Dictionary<string, object> properties)
+        public Task<MixpanelResponse> Set (Dictionary<string, object> properties)
         {
             return Engage ("$set", properties);
         }
@@ -94,9 +97,9 @@ namespace Mixpanel.NET.PCL
         /// Works the same as <see cref="Set"/>
         /// Will only set the value the first time
         /// </summary>
-        /// <returns>True if the set worked, false otherwise</returns>
+        /// <returns>The response from mixpanel</returns>
         /// <param name="properties">Properties of the profile</param>
-        public Task<bool> SetOnce (Dictionary<string, object> properties)
+        public Task<MixpanelResponse> SetOnce (Dictionary<string, object> properties)
         {
             return Engage ("$set_once", properties);
         }
@@ -105,8 +108,9 @@ namespace Mixpanel.NET.PCL
         /// Takes a dictionary containing keys and list values. 
         /// The list values in the request are merged with the existing list on the user profile, ignoring duplicate list values.
         /// </summary>
+        /// <returns>The response from mixpanel</returns>
         /// <param name="properties">Properties.</param>
-        public Task<bool> Union (Dictionary<string, string []> properties)
+        public Task<MixpanelResponse> Union (Dictionary<string, string []> properties)
         {
             return Engage ("$union", properties);
         }
@@ -114,8 +118,9 @@ namespace Mixpanel.NET.PCL
         /// <summary>
         /// Takes an array of string property names, and permanently removes the properties and their values from a profile.
         /// </summary>
+        /// <returns>The response from mixpanel</returns>
         /// <param name="propertyNames">Property names.</param>
-        public Task<bool> Unset (string[] propertyNames)
+        public Task<MixpanelResponse> Unset (string[] propertyNames)
         {
             return Engage ("$unset", propertyNames);
         }
@@ -124,14 +129,14 @@ namespace Mixpanel.NET.PCL
         /// Engage a new user with a distinct id.
         /// This will not add any further information to a profile.
         /// </summary>
-        /// <returns>True if the engage worked, false otherwise</returns>
-        private Task<bool> Engage (string operation, object properties)
+        /// <returns>The response from the mixpanel server</returns>
+        private Task<MixpanelResponse> Engage (string operation, object properties)
         {
             if (properties == null)
             {
                 throw new ArgumentNullException (nameof (properties));
             }
-                
+
             var dataDictionary = new Dictionary<string, object>
             {
                 { "$token", Client.Token },
@@ -142,8 +147,7 @@ namespace Mixpanel.NET.PCL
             var request =
                 RequestHelpers.GetRequestMessageFromDictionaryAndEndpoint (Constants.EngageUri,
                                                                            dataDictionary);
-
-            return RequestHelpers.MakeRequest (request);
+            return RequestHelpers.GetRequestOutput (request);
         }
     }
 }

--- a/src/Mixpanel.NET.PCL/Profile.cs
+++ b/src/Mixpanel.NET.PCL/Profile.cs
@@ -147,7 +147,7 @@ namespace Mixpanel.NET.PCL
             var request =
                 RequestHelpers.GetRequestMessageFromDictionaryAndEndpoint (Constants.EngageUri,
                                                                            dataDictionary);
-            return RequestHelpers.GetRequestOutput (request);
+            return RequestHelpers.MakeRequest (request);
         }
     }
 }

--- a/src/Mixpanel.NET.PCL/RequestHelpers.cs
+++ b/src/Mixpanel.NET.PCL/RequestHelpers.cs
@@ -36,7 +36,7 @@ namespace Mixpanel.NET.PCL
         /// </summary>
         /// <returns>The response from mixpanel</returns>
         /// <param name="request">The http request message</param>
-        internal static async Task<MixpanelResponse> GetRequestOutput(HttpRequestMessage request)
+        internal static async Task<MixpanelResponse> MakeRequest(HttpRequestMessage request)
         {
             using (var client = new HttpClient ())
             {

--- a/src/Mixpanel.NET.PCL/RequestHelpers.cs
+++ b/src/Mixpanel.NET.PCL/RequestHelpers.cs
@@ -5,6 +5,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Mixpanel.NET.PCL
 {
@@ -23,7 +24,7 @@ namespace Mixpanel.NET.PCL
 
             var request = new HttpRequestMessage (HttpMethod.Post, endpoint)
             {
-                Content = new StringContent ($"data={base64String}")
+                Content = new StringContent ($"data={base64String}&verbose=1")
             };
             request.Content.Headers.ContentType = new MediaTypeHeaderValue ("application/x-www-form-urlencoded");
 
@@ -33,21 +34,23 @@ namespace Mixpanel.NET.PCL
         /// <summary>
         /// Makes the http request given a message
         /// </summary>
-        /// <returns>True if the request succeeded, false otherwise</returns>
+        /// <returns>The response from mixpanel</returns>
         /// <param name="request">The http request message</param>
-        internal static async Task<bool> MakeRequest (HttpRequestMessage request)
+        internal static async Task<MixpanelResponse> GetRequestOutput(HttpRequestMessage request)
         {
             using (var client = new HttpClient ())
             {
                 var response = await client.SendAsync (request);
                 if (!response.IsSuccessStatusCode)
                 {
-                    return false;
+                    return new MixpanelResponse(false, $"Request status code: {response.StatusCode}");
                 }
 
                 var responseBody = await response.Content.ReadAsStringAsync ();
 
-                return responseBody == Constants.SuccessResponse;
+                var mixpanelResponse = JsonConvert.DeserializeObject<MixpanelResponse> (responseBody);
+
+                return mixpanelResponse;
             }
         }
     }


### PR DESCRIPTION
Uses `verbose=1` in the url to get a reason why a request failed so the user gets more info.