### PR TITLE
Use https endpoints

### DIFF
--- a/src/Mixpanel.NET.PCL/Constants.cs
+++ b/src/Mixpanel.NET.PCL/Constants.cs
@@ -4,7 +4,7 @@ namespace Mixpanel.NET.PCL
     internal static class Constants
     {
         public const string SuccessResponse = "1";
-        public const string TrackUri = "http://api.mixpanel.com/track/";
-        public const string EngageUri = "http://api.mixpanel.com/engage/";
+        public const string TrackUri = "https://api.mixpanel.com/track/";
+        public const string EngageUri = "https://api.mixpanel.com/engage/";
     }
 }


### PR DESCRIPTION
If you use this in a Xamarin iOS app, it complains about using non-secure endpoints (http). Mixpanel supports https, so lets use them :)